### PR TITLE
Set cache time for total stats instead of no-cache option

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,4 +1,3 @@
-import AppHeader from "@src/features/appHeader/AppHeader"
 import TotalGuidesNumberWidget from "@src/widgets/SingleNumberWidgets/TotalGuidesNumberWidget"
 import TotalUsersNumberWidget from "@src/widgets/SingleNumberWidgets/TotalUsersNumberWidget"
 import TotalCitiesNumberWidget from "@src/widgets/SingleNumberWidgets/TotalCitiesNumberWidget"

--- a/src/features/stats/statsService.ts
+++ b/src/features/stats/statsService.ts
@@ -7,6 +7,9 @@ export type TotalStats = {
   totalGuides: number
 }
 
+// Time in seconds
+export const CACHE_TOTAL_STATS_TIME = 60
+
 export async function fetchTotalStats(): Promise<TotalStats> {
   try {
     const res = await fetch(getApiUrl("/stats/total"), {
@@ -14,7 +17,9 @@ export async function fetchTotalStats(): Promise<TotalStats> {
       headers: {
         "Content-Type": "application/json",
       },
-      cache: "no-store",
+      next: {
+        revalidate: CACHE_TOTAL_STATS_TIME,
+      },
     })
 
     const data: ApiResponse<TotalStats> = await res.json()


### PR DESCRIPTION
### Github issue

- Issue URL: -

### Description

- Having `no-cache` option causes a build error because Next executes it in build time

### Done

- [ ] Added tests

### Demo 
